### PR TITLE
Add CSS class with tag name to each tag

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -18,6 +18,7 @@ import Panel exposing (Panel)
 import Panels exposing (Panels)
 import Parser
 import SafeZipper exposing (SafeZipper)
+import String exposing (replace)
 import TagBoard
 import Task
 import TaskItem exposing (TaskItem)
@@ -1331,7 +1332,7 @@ cardTagsView tags =
 
 cardTagView : String -> Html Msg
 cardTagView tagText =
-    Html.div [ class "card-board-card-tag" ]
+    Html.div [ class ("card-board-card-tag tag-" ++ (replace "/" "-" tagText)) ]
         [ Html.span [ class "cm-hashtag-begin cm-hashtag" ]
             [ Html.text "#" ]
         , Html.span [ class "cm-list-1 cm-hashtag cm-hashtag-end" ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1332,7 +1332,7 @@ cardTagsView tags =
 
 cardTagView : String -> Html Msg
 cardTagView tagText =
-    Html.div [ class ("card-board-card-tag tag-" ++ (replace "/" "-" tagText)) ]
+    Html.div [ class ("card-board-card-tag tag-" ++ replace "/" "-" tagText) ]
         [ Html.span [ class "cm-hashtag-begin cm-hashtag" ]
             [ Html.text "#" ]
         , Html.span [ class "cm-list-1 cm-hashtag cm-hashtag-end" ]


### PR DESCRIPTION
Adds a CSS class to each tag that includes the tag name. Can be useful for changing the CSS for an individual tag separate from other tags.

Handles the case of a tag being within a hierarchy by replacing `/` with `-` so the class name includes the whole tag name but remains valid.

Resolves #24.