### PR TITLE
Return unique list of tags for a card

### DIFF
--- a/src/TaskItem.elm
+++ b/src/TaskItem.elm
@@ -238,6 +238,7 @@ tags ((TaskItem fields_ _) as taskItem) =
     subtasks taskItem
         |> List.concatMap (\(TaskItem fs _) -> fs.tags)
         |> List.append fields_.tags
+        |> LE.unique
 
 
 tasksToToggle : String -> { a | now : Time.Posix } -> TaskItem -> List TaskItem

--- a/tests/TaskItemTests.elm
+++ b/tests/TaskItemTests.elm
@@ -660,6 +660,12 @@ tags =
                     |> Parser.run (TaskItem.parser "" Nothing)
                     |> Result.map TaskItem.tags
                     |> Expect.equal (Ok [ "tag1", "tag2", "tag3" ])
+        , test "returns unique list of tags" <|
+            \() ->
+                "- [ ] foo #tag1 bar #tag2\n  - [ ] bar #tag2"
+                    |> Parser.run (TaskItem.parser "" Nothing)
+                    |> Result.map TaskItem.tags
+                    |> Expect.equal (Ok [ "tag1", "tag2" ])
         , test "tags are not included in the title" <|
             \() ->
                 "- [ ] foo #tag1 bar #tag2"


### PR DESCRIPTION
Fixes #33.

Used `List.Extra` module to return unique list of tags from the `tags` function. I considered converting the return value to a `Set` but was unsure of the knock on effects of this.

Let me know if you think there's a better solution, it's been a while since I've written any Elm! :)