### PR TITLE
Remove Status Tag: Tag used for column will no longer be shown on the card

### DIFF
--- a/src/TagBoard.elm
+++ b/src/TagBoard.elm
@@ -246,6 +246,7 @@ fillColumn taskList columnConfig acc =
     in
     TaskList.filter (isIncompleteWithTag columnConfig.tag) taskList
         |> TaskList.topLevelTasks
+        |> List.map (TaskItem.removeTag columnConfig.tag)
         |> List.sortBy (String.toLower << TaskItem.title)
         |> List.sortBy TaskItem.dueRataDie
         |> Tuple.pair columnConfig.displayTitle

--- a/src/TaskItem.elm
+++ b/src/TaskItem.elm
@@ -366,12 +366,23 @@ toString (TaskItem fields_ _) =
 
 removeTag : String -> TaskItem -> TaskItem
 removeTag tag (TaskItem fields_ subtasks_) =
-    TaskItem { fields_ | tags = List.filter (\t -> t /= tag) fields_.tags } (List.map (removeTagFromFields tag) subtasks_)
+    TaskItem (removeTagFromFields tag fields_) (List.map (removeTagFromFields tag) subtasks_)
 
 
 removeTagFromFields : String -> TaskItemFields -> TaskItemFields
 removeTagFromFields tag fields_ =
-    { fields_ | tags  = List.filter (\t -> t /= tag) fields_.tags }
+    let
+        matches : String -> Bool
+        matches itemTag =
+            if String.endsWith "/" tag then
+                tag == itemTag
+                    || (String.toLower itemTag == String.dropRight 1 (String.toLower tag))
+
+            else
+                String.toLower itemTag == String.toLower tag
+    in
+
+    { fields_ | tags  = List.filter (\t -> not (matches t)) fields_.tags }
 
 
 toggleCompletion : { a | now : Time.Posix } -> TaskItem -> TaskItem

--- a/src/TaskItem.elm
+++ b/src/TaskItem.elm
@@ -24,6 +24,7 @@ module TaskItem exposing
     , notes
     , originalText
     , parser
+    , removeTag
     , subtasks
     , tags
     , tasksToToggle
@@ -41,7 +42,6 @@ import Parser as P exposing ((|.), (|=), Parser)
 import ParserHelper exposing (isSpaceOrTab, lineEndOrEnd)
 import TaskPaperTag
 import Time
-
 
 
 -- TYPES
@@ -362,6 +362,16 @@ toString (TaskItem fields_ _) =
 
 
 -- MODIFICATION
+
+
+removeTag : String -> TaskItem -> TaskItem
+removeTag tag (TaskItem fields_ subtasks_) =
+    TaskItem { fields_ | tags = List.filter (\t -> t /= tag) fields_.tags } (List.map (removeTagFromFields tag) subtasks_)
+
+
+removeTagFromFields : String -> TaskItemFields -> TaskItemFields
+removeTagFromFields tag fields_ =
+    { fields_ | tags  = List.filter (\t -> t /= tag) fields_.tags }
 
 
 toggleCompletion : { a | now : Time.Posix } -> TaskItem -> TaskItem

--- a/tests/TagBoardTests.elm
+++ b/tests/TagBoardTests.elm
@@ -183,6 +183,22 @@ columnsBasic =
                     |> tasksInColumn "At Tasks"
                     |> List.map TaskItem.title
                     |> Expect.equal [ "bar1", "bar2" ]
+        , test "removes tags that match the column's tag" <|
+            \() ->
+                """- [ ] foo #foo
+- [ ] bar1 #bar/
+  - [ ] bar1.1 #bar/baz
+- [ ] bar2 #bar #baz
+"""
+                    |> Parser.run (TaskList.parser "" Nothing)
+                    |> Result.withDefault TaskList.empty
+                    |> TagBoard.columns
+                        { defaultConfig
+                            | columns = [ { tag = "bar/", displayTitle = "Bar Tasks" } ]
+                        }
+                    |> tasksInColumn "Bar Tasks"
+                    |> List.concatMap TaskItem.tags
+                    |> Expect.equal [ "bar/baz", "baz"  ]
         , test "sorts cards by title & due date" <|
             \() ->
                 """- [ ] b #foo @due(2020-01-01)

--- a/tests/TaskItemTests.elm
+++ b/tests/TaskItemTests.elm
@@ -29,6 +29,7 @@ suite =
         , notes
         , originalText
         , parsing
+        , removeTag
         , subtasks
         , tags
         , tasksToToggle
@@ -607,6 +608,47 @@ parsing =
                     |> Expect.equal (Err "failed")
         ]
 
+
+removeTag : Test
+removeTag =
+    describe "removeTag"
+        [ test "removes column tag when it's the only tag" <|
+            \() ->
+                "- [ ] foo #bar"
+                    |> Parser.run (TaskItem.parser "" Nothing)
+                    |> Result.map (TaskItem.removeTag "bar")
+                    |> Result.map TaskItem.toString
+                    |> Expect.equal (Ok "- [ ] foo")
+        , test "remove column tag when there are other tags present" <|
+            \() ->
+                "- [ ] foo #bar #baz"
+                    |> Parser.run (TaskItem.parser "" Nothing)
+                    |> Result.map (TaskItem.removeTag "bar")
+                    |> Result.map TaskItem.toString
+                    |> Expect.equal (Ok "- [ ] foo #baz")
+        , test "remove column tag when there is another tag that starts with the same" <|
+            \() ->
+                "- [ ] foo #bar #bart"
+                    |> Parser.run (TaskItem.parser "" Nothing)
+                    |> Result.map (TaskItem.removeTag "bar")
+                    |> Result.map TaskItem.toString
+                    |> Expect.equal (Ok "- [ ] foo #bart")
+        , test "remove column tag when tag includes a slash" <|
+            \() ->
+                "- [ ] foo #bar/ #baz"
+                    |> Parser.run (TaskItem.parser "" Nothing)
+                    |> Result.map (TaskItem.removeTag "bar/")
+                    |> Result.map TaskItem.toString
+                    |> Expect.equal (Ok "- [ ] foo #baz")
+        , test "remove column tag when tag is on a subtask" <|
+            \() ->
+                "- [ ] foo #baz\n  - [ ] bar #bar"
+                    |> Parser.run (TaskItem.parser "" Nothing)
+                    |> Result.map (TaskItem.removeTag "bar")
+                    |> Result.map (TaskItem.subtasks)
+                    |> Result.map (List.map TaskItem.toString)
+                    |> Expect.equal (Ok [ "  - [ ] bar" ])
+        ]
 
 subtasks : Test
 subtasks =

--- a/tests/TaskItemTests.elm
+++ b/tests/TaskItemTests.elm
@@ -612,35 +612,42 @@ parsing =
 removeTag : Test
 removeTag =
     describe "removeTag"
-        [ test "removes column tag when it's the only tag" <|
+        [ test "removes tag when it's the only tag" <|
             \() ->
                 "- [ ] foo #bar"
                     |> Parser.run (TaskItem.parser "" Nothing)
                     |> Result.map (TaskItem.removeTag "bar")
                     |> Result.map TaskItem.toString
                     |> Expect.equal (Ok "- [ ] foo")
-        , test "remove column tag when there are other tags present" <|
+        , test "remove tag when there are other tags present" <|
             \() ->
                 "- [ ] foo #bar #baz"
                     |> Parser.run (TaskItem.parser "" Nothing)
                     |> Result.map (TaskItem.removeTag "bar")
                     |> Result.map TaskItem.toString
                     |> Expect.equal (Ok "- [ ] foo #baz")
-        , test "remove column tag when there is another tag that starts with the same" <|
+        , test "remove tag when there is another tag that starts with the same" <|
             \() ->
                 "- [ ] foo #bar #bart"
                     |> Parser.run (TaskItem.parser "" Nothing)
                     |> Result.map (TaskItem.removeTag "bar")
                     |> Result.map TaskItem.toString
                     |> Expect.equal (Ok "- [ ] foo #bart")
-        , test "remove column tag when tag includes a slash" <|
+        , test "remove tag when tag includes a slash" <|
             \() ->
                 "- [ ] foo #bar/ #baz"
                     |> Parser.run (TaskItem.parser "" Nothing)
                     |> Result.map (TaskItem.removeTag "bar/")
                     |> Result.map TaskItem.toString
                     |> Expect.equal (Ok "- [ ] foo #baz")
-        , test "remove column tag when tag is on a subtask" <|
+        , test "it will not remove sub-tags when a trailing slash is given" <|
+            \() ->
+                "- [ ] foo #bar/qux #baz"
+                    |> Parser.run (TaskItem.parser "" Nothing)
+                    |> Result.map (TaskItem.removeTag "bar/")
+                    |> Result.map TaskItem.toString
+                    |> Expect.equal (Ok "- [ ] foo #bar/qux #baz")
+        , test "remove tag when tag is on a subtask" <|
             \() ->
                 "- [ ] foo #baz\n  - [ ] bar #bar"
                     |> Parser.run (TaskItem.parser "" Nothing)


### PR DESCRIPTION
When filling the columns on a TagBoard, the tag used for that column will be removed from the TaskItem tag list as well as from the TaskIItemFields that make up the subtasks.

Includes tests for the `removeTag` method. There wasn't one that I saw for `fillColumn` so I didn't add anything for that method. Manual verification was done on a test vault.

Resolves #5 