### PR TITLE
TagsSet: Convert TaskItem.tags from List to Set

### DIFF
--- a/tests/TagBoardTests.elm
+++ b/tests/TagBoardTests.elm
@@ -8,6 +8,7 @@ import TaskList
 import Test exposing (..)
 import TsJson.Decode as TsDecode
 import TsJson.Encode as TsEncode
+import Set
 
 
 suite : Test
@@ -197,8 +198,9 @@ columnsBasic =
                             | columns = [ { tag = "bar/", displayTitle = "Bar Tasks" } ]
                         }
                     |> tasksInColumn "Bar Tasks"
-                    |> List.concatMap TaskItem.tags
-                    |> Expect.equal [ "bar/baz", "baz"  ]
+                    |> List.map TaskItem.tags
+                    |> List.foldl (Set.union) Set.empty
+                    |> Expect.equalSets (Set.fromList [ "bar/baz", "baz" ])
         , test "sorts cards by title & due date" <|
             \() ->
                 """- [ ] b #foo @due(2020-01-01)

--- a/tests/TaskItemTests.elm
+++ b/tests/TaskItemTests.elm
@@ -6,6 +6,7 @@ import Parser exposing ((|=))
 import TaskItem exposing (AutoCompletion(..), Completion(..))
 import Test exposing (..)
 import Time
+import Set
 
 
 suite : Test
@@ -710,19 +711,19 @@ tags =
                 "- [ ] foo"
                     |> Parser.run (TaskItem.parser "" Nothing)
                     |> Result.map TaskItem.tags
-                    |> Expect.equal (Ok [])
+                    |> Expect.equal (Ok Set.empty)
         , test "returns all tags from the top level and sub tasks" <|
             \() ->
                 "- [ ] foo #tag1 bar #tag2\n  - [ ] bar #tag3"
                     |> Parser.run (TaskItem.parser "" Nothing)
                     |> Result.map TaskItem.tags
-                    |> Expect.equal (Ok [ "tag1", "tag2", "tag3" ])
+                    |> Expect.equal (Ok (Set.fromList [ "tag1", "tag2", "tag3" ]))
         , test "returns unique list of tags" <|
             \() ->
                 "- [ ] foo #tag1 bar #tag2\n  - [ ] bar #tag2"
                     |> Parser.run (TaskItem.parser "" Nothing)
                     |> Result.map TaskItem.tags
-                    |> Expect.equal (Ok [ "tag1", "tag2" ])
+                    |> Expect.equal (Ok (Set.fromList [ "tag1", "tag2" ]))
         , test "tags are not included in the title" <|
             \() ->
                 "- [ ] foo #tag1 bar #tag2"


### PR DESCRIPTION
Behind the scenes update to convert TaskItem.tags from a List to a Set. Has the benefit of enforcing uniqueness through the whole process instead of using List.unique at the end.

Ended up not having to bring in or build any sort of Set.Extra package as everything could be done with the core library. Could maybe have implemented a concatMap type method but I needed to build a Set from a List (List TaskItem -> Set String) so it made more sense to just pipe a couple method calls.

Fixes #52 