### PR TITLE
GlobalSubtaskSettings: Handles hideCompletedSubtasks and subTaskDisplayLimit GlobalSettings values

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -60,6 +60,8 @@
 - when clicking the edit button place the cursor at the line of the todo
   have tried to do this using setCursor and not go it to work so far
 - display on card - done date
+- hide tag on card if it only exists on a completed subtask?
+  - Decided against for now to keep it simple, but may revist in future
 
 # Theme Compatibility
 - Firefly Theme: why is the text so big?

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,3 @@
-- write settings back on launch (from elm) so that you are always on the latest version
-- do I need to export CardBoardSettings.defaultGlobalSettings?
-
 # Task Formats
 - https://github.com/schemar/obsidian-tasks
 - https://logseq.github.io/#/page/tasks%20%26%20todos

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
+- write settings back on launch (from elm) so that you are always on the latest version
 - do I need to export CardBoardSettings.defaultGlobalSettings?
 
 # Task Formats

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
-- forgot to update the tests for InteropDefinitions!
-- do I want to rename Panel -> Board ??
+- do I need to export CardBoardSettings.defaultGlobalSettings?
 
 # Task Formats
 - https://github.com/schemar/obsidian-tasks
@@ -89,6 +88,7 @@
   For a date picker.
 
 # Misc
+- do I want to rename Panel -> Board ??
 - https://allcontributors.org/docs/en/overview
 - how small can I make the compliled js?
   https://discourse.elm-lang.org/t/what-i-ve-learned-about-minifying-elm-code/7632

--- a/src/BoardConfig.elm
+++ b/src/BoardConfig.elm
@@ -1,6 +1,7 @@
 module BoardConfig exposing
     ( BoardConfig(..)
     , decoder
+    , decoder_v_0_1_0
     , default
     , encoder
     , fromBoardType
@@ -107,4 +108,12 @@ decoder =
     TsDecode.oneOf
         [ DecodeHelpers.toElmVariant "dateBoardConfig" DateBoardConfig DateBoard.configDecoder
         , DecodeHelpers.toElmVariant "tagBoardConfig" TagBoardConfig TagBoard.configDecoder
+        ]
+
+
+decoder_v_0_1_0 : TsDecode.Decoder BoardConfig
+decoder_v_0_1_0 =
+    TsDecode.oneOf
+        [ DecodeHelpers.toElmVariant "dateBoardConfig" DateBoardConfig DateBoard.configDecoder_v_0_1_0
+        , DecodeHelpers.toElmVariant "tagBoardConfig" TagBoardConfig TagBoard.configDecoder_v_0_1_0
         ]

--- a/src/CardBoardSettings.elm
+++ b/src/CardBoardSettings.elm
@@ -126,7 +126,7 @@ currentVersionDecoder : TsDecode.Decoder Settings
 currentVersionDecoder =
     TsDecode.succeed Settings
         |> TsDecode.andMap (TsDecode.field "boardConfigs" (TsDecode.list BoardConfig.decoder))
-        |> TsDecode.andMap (TsDecode.field "globalSettings" defaultGlobalSettingsDecoder)
+        |> TsDecode.andMap (TsDecode.field "globalSettings" globalSettingsDecoder)
         |> TsDecode.andMap (TsDecode.succeed currentVersion)
 
 
@@ -141,6 +141,14 @@ v_0_1_0_Decoder =
 unsupportedVersionDecoder : TsDecode.Decoder Settings
 unsupportedVersionDecoder =
     TsDecode.fail "Unsupported settings file version"
+
+
+globalSettingsDecoder : TsDecode.Decoder GlobalSettings
+globalSettingsDecoder =
+    TsDecode.succeed GlobalSettings
+        |> TsDecode.andMap (TsDecode.field "hideCompletedSubtasks" TsDecode.bool)
+        |> TsDecode.andMap (TsDecode.field "ignorePaths" TsDecode.string)
+        |> TsDecode.andMap (TsDecode.field "subTaskDisplayLimit" (TsDecode.maybe TsDecode.int))
 
 
 defaultGlobalSettingsDecoder : TsDecode.Decoder GlobalSettings

--- a/src/CardBoardSettings.elm
+++ b/src/CardBoardSettings.elm
@@ -133,7 +133,7 @@ currentVersionDecoder =
 v_0_1_0_Decoder : TsDecode.Decoder Settings
 v_0_1_0_Decoder =
     TsDecode.succeed Settings
-        |> TsDecode.andMap (TsDecode.field "boardConfigs" (TsDecode.list BoardConfig.decoder))
+        |> TsDecode.andMap (TsDecode.field "boardConfigs" (TsDecode.list BoardConfig.decoder_v_0_1_0))
         |> TsDecode.andMap (TsDecode.succeed defaultGlobalSettings)
         |> TsDecode.andMap (TsDecode.succeed currentVersion)
 

--- a/src/CardBoardSettings.elm
+++ b/src/CardBoardSettings.elm
@@ -6,6 +6,7 @@ module CardBoardSettings exposing
     , decoder
     , defaultGlobalSettings
     , encoder
+    , globalSettings
     )
 
 import BoardConfig exposing (BoardConfig)
@@ -52,6 +53,11 @@ defaultGlobalSettings =
 boardConfigs : Settings -> List BoardConfig
 boardConfigs =
     .boardConfigs
+
+
+globalSettings : Settings -> GlobalSettings
+globalSettings =
+    .globalSettings
 
 
 

--- a/src/DateBoard.elm
+++ b/src/DateBoard.elm
@@ -2,6 +2,7 @@ module DateBoard exposing
     ( Config
     , columns
     , configDecoder
+    , configDecoder_v_0_1_0
     , configEncoder
     , defaultConfig
     )
@@ -20,6 +21,8 @@ import TsJson.Encode as TsEncode
 
 type alias Config =
     { completedCount : Int
+    , filterPaths : String
+    , filterTags : String
     , includeUndated : Bool
     , title : String
     }
@@ -28,6 +31,8 @@ type alias Config =
 defaultConfig : Config
 defaultConfig =
     { completedCount = 10
+    , filterPaths = ""
+    , filterTags = ""
     , includeUndated = True
     , title = ""
     }
@@ -42,6 +47,8 @@ configEncoder =
     TsEncode.object
         [ TsEncode.required "completedCount" .completedCount TsEncode.int
         , TsEncode.required "includeUndated" .includeUndated TsEncode.bool
+        , TsEncode.required "filterPaths" .filterPaths TsEncode.string
+        , TsEncode.required "filterTags" .filterTags TsEncode.string
         , TsEncode.required "title" .title TsEncode.string
         ]
 
@@ -50,6 +57,18 @@ configDecoder : TsDecode.Decoder Config
 configDecoder =
     TsDecode.succeed Config
         |> TsDecode.andMap (TsDecode.field "completedCount" TsDecode.int)
+        |> TsDecode.andMap (TsDecode.field "filterPaths" TsDecode.string)
+        |> TsDecode.andMap (TsDecode.field "filterTags" TsDecode.string)
+        |> TsDecode.andMap (TsDecode.field "includeUndated" TsDecode.bool)
+        |> TsDecode.andMap (TsDecode.field "title" TsDecode.string)
+
+
+configDecoder_v_0_1_0 : TsDecode.Decoder Config
+configDecoder_v_0_1_0 =
+    TsDecode.succeed Config
+        |> TsDecode.andMap (TsDecode.field "completedCount" TsDecode.int)
+        |> TsDecode.andMap (TsDecode.succeed "")
+        |> TsDecode.andMap (TsDecode.succeed "")
         |> TsDecode.andMap (TsDecode.field "includeUndated" TsDecode.bool)
         |> TsDecode.andMap (TsDecode.field "title" TsDecode.string)
 

--- a/src/InteropPorts.elm
+++ b/src/InteropPorts.elm
@@ -24,11 +24,6 @@ import TsJson.Decode as TsDecode
 import TsJson.Encode as TsEncode
 
 
-currentSettingsVersion : Semver.Version
-currentSettingsVersion =
-    Semver.version 0 1 0 [] []
-
-
 toElm : Sub (Result Json.Decode.Error InteropDefinitions.ToElm)
 toElm =
     (InteropDefinitions.interop.toElm |> TsDecode.decoder)
@@ -92,7 +87,10 @@ rewriteTasks timeWithZone filePath taskItems =
 
 updateSettings : SafeZipper BoardConfig -> Cmd msg
 updateSettings configs =
-    { version = currentSettingsVersion, boardConfigs = SafeZipper.toList configs }
+    { version = CardBoardSettings.currentVersion
+    , boardConfigs = SafeZipper.toList configs
+    , globalSettings = CardBoardSettings.defaultGlobalSettings
+    }
         |> encodeVariant "updateSettings" CardBoardSettings.encoder
         |> interopFromElm
 

--- a/src/InteropPorts.elm
+++ b/src/InteropPorts.elm
@@ -12,7 +12,7 @@ port module InteropPorts exposing
 
 import BoardConfig exposing (BoardConfig)
 import Card exposing (Card)
-import CardBoardSettings
+import CardBoardSettings exposing (GlobalSettings)
 import InteropDefinitions
 import Json.Decode
 import Json.Encode
@@ -85,11 +85,11 @@ rewriteTasks timeWithZone filePath taskItems =
         |> interopFromElm
 
 
-updateSettings : SafeZipper BoardConfig -> Cmd msg
-updateSettings configs =
+updateSettings : { a | boardConfigs : SafeZipper BoardConfig, globalSettings : GlobalSettings } -> Cmd msg
+updateSettings settings =
     { version = CardBoardSettings.currentVersion
-    , boardConfigs = SafeZipper.toList configs
-    , globalSettings = CardBoardSettings.defaultGlobalSettings
+    , boardConfigs = SafeZipper.toList settings.boardConfigs
+    , globalSettings = settings.globalSettings
     }
         |> encodeVariant "updateSettings" CardBoardSettings.encoder
         |> interopFromElm

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -282,7 +282,7 @@ view model =
         State.Loaded taskList ->
             Html.div [ class "card-board" ]
                 [ Html.div [ class "card-board-container" ]
-                    [ BoardPage.view model.timeWithZone model.boardConfigs taskList
+                    [ BoardPage.view model.globalSettings model.timeWithZone model.boardConfigs taskList
                         |> Html.map GotBoardPageMsg
                     , SettingsPage.dialogs model.configBeingEdited
                         |> Html.map GotSettingsPageMsg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -39,8 +39,15 @@ init flags =
             ( Model.default, Cmd.none )
 
         Ok okFlags ->
-            ( Model.fromFlags okFlags
-            , Task.perform ReceiveTime <| Task.map2 Tuple.pair Time.here Time.now
+            let
+                model =
+                    Model.fromFlags okFlags
+            in
+            ( model
+            , Cmd.batch
+                [ InteropPorts.updateSettings model
+                , Task.perform ReceiveTime <| Task.map2 Tuple.pair Time.here Time.now
+                ]
             )
 
 

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -20,7 +20,7 @@ module Model exposing
 
 import BoardConfig exposing (BoardConfig)
 import Card exposing (Card)
-import CardBoardSettings
+import CardBoardSettings exposing (GlobalSettings)
 import InteropDefinitions
 import Panels
 import SafeZipper exposing (SafeZipper)
@@ -38,6 +38,7 @@ import TimeWithZone exposing (TimeWithZone)
 type alias Model =
     { boardConfigs : SafeZipper BoardConfig
     , configBeingEdited : EditState
+    , globalSettings : GlobalSettings
     , isActiveView : Bool
     , taskList : State TaskList
     , timeWithZone : TimeWithZone
@@ -55,6 +56,7 @@ default : Model
 default =
     { boardConfigs = SafeZipper.empty
     , configBeingEdited = Adding SafeZipper.empty BoardConfig.default
+    , globalSettings = CardBoardSettings.defaultGlobalSettings
     , isActiveView = False
     , taskList = State.Waiting
     , timeWithZone =
@@ -72,6 +74,7 @@ fromFlags flags =
     in
     { boardConfigs = boardConfigs
     , configBeingEdited = NotEditing
+    , globalSettings = CardBoardSettings.globalSettings flags.settings
     , isActiveView = False
     , taskList = State.Waiting
     , timeWithZone =

--- a/src/Page/Board.elm
+++ b/src/Page/Board.elm
@@ -293,16 +293,28 @@ notesView notesId =
 subtasksView : GlobalSettings -> List ( String, TaskItem ) -> Html Msg
 subtasksView globalSettings subtasks =
     let
-        filteredList list = 
+        maybeFilterList list = 
             if globalSettings.hideCompletedSubtasks then
                 List.filter (\(_, s) -> not (TaskItem.isCompleted s)) list
 
             else
                 list
+
+        displayLimit =
+            Maybe.withDefault 0 globalSettings.subTaskDisplayLimit
+
+        maybeShortenList list =
+            if (displayLimit > 0) then
+                List.take displayLimit list
+
+            else
+                list
+            
     in
     Html.div [ class "card-board-card-subtasks-area" ]
         [ Html.ul [ class "contains-task-list" ]
-            (filteredList subtasks
+            (maybeFilterList subtasks
+                |> maybeShortenList
                 |> List.map subtaskView)
         ]
 

--- a/src/Page/Board.elm
+++ b/src/Page/Board.elm
@@ -23,6 +23,8 @@ import TaskItem exposing (TaskItem, TaskItemFields)
 import TaskList exposing (TaskList)
 import TimeWithZone exposing (TimeWithZone)
 import CardBoardSettings exposing (globalSettings)
+import String exposing (toInt)
+import TaskItem exposing (toString)
 
 
 
@@ -254,6 +256,8 @@ cardView globalSettings timeWithZone card =
                 |> when (TaskItem.hasTags taskItem)
             , subtasksView globalSettings (Card.subtasks card)
                 |> when (TaskItem.hasSubtasks taskItem)
+            , subtaskCountView (TaskItem.subtasks taskItem)
+                |> when (TaskItem.hasSubtasks taskItem)
             , notesView (Card.notesId card)
                 |> when (TaskItem.hasNotes taskItem)
             , Html.div [ class "card-board-card-footer-area" ]
@@ -332,6 +336,25 @@ subtaskView ( uniqueId, subtask ) =
         , Html.div [ class "card-board-card-title", id uniqueId ]
             []
         ]
+
+
+subtaskCountView : List TaskItem -> Html Msg
+subtaskCountView subtasks =
+    let
+        completeSubtasks =
+            List.filter (\s -> TaskItem.isCompleted s) subtasks
+                |> List.length
+                |> String.fromInt
+
+        incompleteSubtaks =
+            List.filter (\s -> not (TaskItem.isCompleted s)) subtasks
+                |> List.length
+                |> String.fromInt
+    in
+        Html.div [ class "card-board-subtask-count" ]
+            [ Html.div [ class "card-board-subtask-count-data" ] 
+                [Html.text (completeSubtasks ++ " / " ++ incompleteSubtaks) ]
+            ]
 
 
 taskDueDate : Maybe Date -> Html Msg

--- a/src/Page/Board.elm
+++ b/src/Page/Board.elm
@@ -254,7 +254,7 @@ cardView globalSettings timeWithZone card =
                 |> when (TaskItem.hasTags taskItem)
             , subtasksView globalSettings (Card.subtasks card)
                 |> when (TaskItem.hasSubtasks taskItem)
-            , subtaskCountView (TaskItem.subtasks taskItem)
+            , subtaskCountView (Card.subtasks card)
                 |> when (TaskItem.hasSubtasks taskItem)
             , notesView (Card.notesId card)
                 |> when (TaskItem.hasNotes taskItem)
@@ -295,7 +295,7 @@ notesView notesId =
 subtasksView : GlobalSettings -> List ( String, TaskItem ) -> Html Msg
 subtasksView globalSettings subtasks =
     let
-        maybeFilterList list = 
+        maybeHideCompletedList list =
             if globalSettings.hideCompletedSubtasks then
                 List.filter (\(_, s) -> not (TaskItem.isCompleted s)) list
 
@@ -311,11 +311,11 @@ subtasksView globalSettings subtasks =
 
             else
                 list
-            
+
     in
     Html.div [ class "card-board-card-subtasks-area" ]
         [ Html.ul [ class "contains-task-list" ]
-            (maybeFilterList subtasks
+            (maybeHideCompletedList subtasks
                 |> maybeShortenList
                 |> List.map subtaskView)
         ]
@@ -336,21 +336,21 @@ subtaskView ( uniqueId, subtask ) =
         ]
 
 
-subtaskCountView : List TaskItem -> Html Msg
+subtaskCountView : List ( String, TaskItem ) -> Html Msg
 subtaskCountView subtasks =
     let
         completeSubtasks =
-            List.filter (\s -> TaskItem.isCompleted s) subtasks
+            List.filter (\(_, s) -> TaskItem.isCompleted s) subtasks
                 |> List.length
                 |> String.fromInt
 
-        totalSubtaks =
+        totalSubtasks =
             List.length subtasks
                 |> String.fromInt
     in
         Html.div [ class "card-board-subtask-count" ]
-            [ Html.div [ class "card-board-subtask-count-data" ] 
-                [Html.text (completeSubtasks ++ " / " ++ totalSubtaks) ]
+            [ Html.div [ class "card-board-subtask-count-data" ]
+                [Html.text (completeSubtasks ++ " / " ++ totalSubtasks) ]
             ]
 
 

--- a/src/Page/Board.elm
+++ b/src/Page/Board.elm
@@ -22,9 +22,6 @@ import SafeZipper exposing (SafeZipper)
 import TaskItem exposing (TaskItem, TaskItemFields)
 import TaskList exposing (TaskList)
 import TimeWithZone exposing (TimeWithZone)
-import CardBoardSettings exposing (globalSettings)
-import String exposing (toInt)
-import TaskItem exposing (toString)
 import Card exposing (subtasks)
 
 

--- a/src/Page/Board.elm
+++ b/src/Page/Board.elm
@@ -25,6 +25,7 @@ import TimeWithZone exposing (TimeWithZone)
 import CardBoardSettings exposing (globalSettings)
 import String exposing (toInt)
 import TaskItem exposing (toString)
+import Card exposing (subtasks)
 
 
 
@@ -346,14 +347,13 @@ subtaskCountView subtasks =
                 |> List.length
                 |> String.fromInt
 
-        incompleteSubtaks =
-            List.filter (\s -> not (TaskItem.isCompleted s)) subtasks
-                |> List.length
+        totalSubtaks =
+            List.length subtasks
                 |> String.fromInt
     in
         Html.div [ class "card-board-subtask-count" ]
             [ Html.div [ class "card-board-subtask-count-data" ] 
-                [Html.text (completeSubtasks ++ " / " ++ incompleteSubtaks) ]
+                [Html.text (completeSubtasks ++ " / " ++ totalSubtaks) ]
             ]
 
 

--- a/src/Page/Settings.elm
+++ b/src/Page/Settings.elm
@@ -285,7 +285,7 @@ closeDialogOrExit model =
                 cmd =
                     if SafeZipper.length config == 0 then
                         Cmd.batch
-                            [ InteropPorts.updateSettings config
+                            [ InteropPorts.updateSettings model
                             , InteropPorts.closeView
                             ]
 
@@ -304,7 +304,7 @@ closeDialogOrExit model =
 
         Model.Editing config ->
             ( { model | configBeingEdited = Model.NotEditing }
-            , InteropPorts.updateSettings config
+            , InteropPorts.updateSettings model
             )
 
         _ ->

--- a/src/TagBoard.elm
+++ b/src/TagBoard.elm
@@ -4,6 +4,7 @@ module TagBoard exposing
     , columnConfigsParser
     , columns
     , configDecoder
+    , configDecoder_v_0_1_0
     , configEncoder
     , defaultConfig
     )
@@ -25,6 +26,8 @@ import TsJson.Encode as TsEncode
 type alias Config =
     { columns : List ColumnConfig
     , completedCount : Int
+    , filterPaths : String
+    , filterTags : String
     , includeOthers : Bool
     , includeUntagged : Bool
     , title : String
@@ -41,6 +44,8 @@ defaultConfig : Config
 defaultConfig =
     { columns = []
     , completedCount = 10
+    , filterPaths = ""
+    , filterTags = ""
     , includeOthers = False
     , includeUntagged = False
     , title = ""
@@ -56,6 +61,8 @@ configEncoder =
     TsEncode.object
         [ TsEncode.required "columns" .columns <| TsEncode.list columnConfigEncoder
         , TsEncode.required "completedCount" .completedCount TsEncode.int
+        , TsEncode.required "filterPaths" .filterPaths TsEncode.string
+        , TsEncode.required "filterTags" .filterTags TsEncode.string
         , TsEncode.required "includeOthers" .includeOthers TsEncode.bool
         , TsEncode.required "includeUntagged" .includeUntagged TsEncode.bool
         , TsEncode.required "title" .title TsEncode.string
@@ -75,6 +82,20 @@ configDecoder =
     TsDecode.succeed Config
         |> TsDecode.andMap (TsDecode.field "columns" (TsDecode.list columnConfigDecoder))
         |> TsDecode.andMap (TsDecode.field "completedCount" TsDecode.int)
+        |> TsDecode.andMap (TsDecode.field "filterPaths" TsDecode.string)
+        |> TsDecode.andMap (TsDecode.field "filterTags" TsDecode.string)
+        |> TsDecode.andMap (TsDecode.field "includeOthers" TsDecode.bool)
+        |> TsDecode.andMap (TsDecode.field "includeUntagged" TsDecode.bool)
+        |> TsDecode.andMap (TsDecode.field "title" TsDecode.string)
+
+
+configDecoder_v_0_1_0 : TsDecode.Decoder Config
+configDecoder_v_0_1_0 =
+    TsDecode.succeed Config
+        |> TsDecode.andMap (TsDecode.field "columns" (TsDecode.list columnConfigDecoder))
+        |> TsDecode.andMap (TsDecode.field "completedCount" TsDecode.int)
+        |> TsDecode.andMap (TsDecode.succeed "")
+        |> TsDecode.andMap (TsDecode.succeed "")
         |> TsDecode.andMap (TsDecode.field "includeOthers" TsDecode.bool)
         |> TsDecode.andMap (TsDecode.field "includeUntagged" TsDecode.bool)
         |> TsDecode.andMap (TsDecode.field "title" TsDecode.string)

--- a/styles.css
+++ b/styles.css
@@ -152,6 +152,7 @@ ul.card-board-column-list > li.card-board-card::before {
 
 .card-board-card-content-area {
   grid-area: contents;
+  position: relative;
   display: grid;
   padding: 0.5em;
   grid: "tags        tags"
@@ -206,6 +207,18 @@ div.card-board-card-tag > span.cm-hashtag.cm-hashtag-end {
     border-left: none;
     padding-right: 6px;
     border-right: 1px solid var(--background-modifier-border);
+}
+
+.card-board-card-content-area div.card-board-subtask-count {
+  grid-area: tags;
+}
+
+.card-board-card-content-area div.card-board-subtask-count-data {
+  float: right;
+  top: 0px;
+  right: 0px;
+  color: var(--text-faint);
+  font-size: var(--font-small);
 }
 
 .card-board-card.markdown-preview-view .task-list-item-checkbox {

--- a/tests/BoardConfigTests.elm
+++ b/tests/BoardConfigTests.elm
@@ -30,19 +30,7 @@ default =
 encodeDecode : Test
 encodeDecode =
     describe "encoding and decoding config"
-        [ test "encodes config correctly" <|
-            \() ->
-                defaultConfig
-                    |> TsEncode.runExample BoardConfig.encoder
-                    |> .output
-                    |> Expect.equal """{"tag":"tagBoardConfig","data":{"columns":[],"completedCount":10,"includeOthers":false,"includeUntagged":false,"title":""}}"""
-        , test "produces the expected type" <|
-            \() ->
-                defaultConfig
-                    |> TsEncode.runExample BoardConfig.encoder
-                    |> .tsType
-                    |> Expect.equal """{ data : { columns : { displayTitle : string; tag : string }[]; completedCount : number; includeOthers : boolean; includeUntagged : boolean; title : string }; tag : "tagBoardConfig" } | { data : { completedCount : number; includeUndated : boolean; title : string }; tag : "dateBoardConfig" }"""
-        , test "can decode the encoded string back to the original" <|
+        [ test "can decode an encoded string back to the original" <|
             \() ->
                 defaultConfig
                     |> TsEncode.runExample BoardConfig.encoder

--- a/tests/CardBoardSettingsTests.elm
+++ b/tests/CardBoardSettingsTests.elm
@@ -11,32 +11,26 @@ import TsJson.Encode as TsEncode
 suite : Test
 suite =
     concat
-        [ encodeDecode
+        [ currentVersion
+        , encodeDecode
+        ]
+
+
+currentVersion : Test
+currentVersion =
+    describe "currentVersion"
+        [ test "is 0.2.0" <|
+            \() ->
+                CardBoardSettings.currentVersion
+                    |> Semver.print
+                    |> Expect.equal "0.2.0"
         ]
 
 
 encodeDecode : Test
 encodeDecode =
     describe "encoding and decoding settings"
-        [ test "encodes settings correctly" <|
-            \() ->
-                defaultSettings
-                    |> TsEncode.runExample CardBoardSettings.encoder
-                    |> .output
-                    |> Expect.equal """{"version":"0.1.0","data":{"boardConfigs":[]}}"""
-        , test "produces the expected type" <|
-            \() ->
-                defaultSettings
-                    |> TsEncode.runExample CardBoardSettings.encoder
-                    |> .tsType
-                    |> Expect.equal
-                        ("{ data : { boardConfigs : ("
-                            ++ "{ data : { columns : { displayTitle : string; tag : string }[]; completedCount : number; includeOthers : boolean; includeUntagged : boolean; title : string }; tag : \"tagBoardConfig\" } | "
-                            ++ "{ data : { completedCount : number; includeUndated : boolean; title : string }; tag : \"dateBoardConfig\" }"
-                            ++ ")[] }; "
-                            ++ "version : string }"
-                        )
-        , test "can decode the encoded string back to the original" <|
+        [ test "can decode the encoded string back to the original" <|
             \() ->
                 defaultSettings
                     |> TsEncode.runExample CardBoardSettings.encoder
@@ -63,7 +57,16 @@ encodeDecode =
 defaultSettings : CardBoardSettings.Settings
 defaultSettings =
     { boardConfigs = []
-    , version = Semver.version 0 1 0 [] []
+    , globalSettings = defaultGlobalSettings
+    , version = Semver.version 0 2 0 [] []
+    }
+
+
+defaultGlobalSettings : CardBoardSettings.GlobalSettings
+defaultGlobalSettings =
+    { hideCompletedSubtasks = False
+    , ignorePaths = ""
+    , subTaskDisplayLimit = Nothing
     }
 
 

--- a/tests/CardBoardSettingsTests.elm
+++ b/tests/CardBoardSettingsTests.elm
@@ -1,5 +1,6 @@
 module CardBoardSettingsTests exposing (suite)
 
+import BoardConfig
 import CardBoardSettings
 import Expect
 import Semver
@@ -32,15 +33,15 @@ encodeDecode =
     describe "encoding and decoding settings"
         [ test "can decode the encoded string back to the original" <|
             \() ->
-                defaultSettings
+                exampleSettings
                     |> TsEncode.runExample CardBoardSettings.encoder
                     |> .output
                     |> runDecoder CardBoardSettings.decoder
                     |> .decoded
-                    |> Expect.equal (Ok defaultSettings)
+                    |> Expect.equal (Ok exampleSettings)
         , test "fails if the version number is unsupported" <|
             \() ->
-                { defaultSettings | version = Semver.version 0 0 0 [] [] }
+                { exampleSettings | version = Semver.version 0 0 0 [] [] }
                     |> TsEncode.runExample CardBoardSettings.encoder
                     |> .output
                     |> runDecoder CardBoardSettings.decoder
@@ -54,19 +55,36 @@ encodeDecode =
 -- HELPERS
 
 
-defaultSettings : CardBoardSettings.Settings
-defaultSettings =
-    { boardConfigs = []
-    , globalSettings = defaultGlobalSettings
+exampleSettings : CardBoardSettings.Settings
+exampleSettings =
+    { boardConfigs =
+        [ BoardConfig.TagBoardConfig
+            { columns = [ { tag = "foo", displayTitle = "bar" } ]
+            , completedCount = 10
+            , filterPaths = "path1\npath2"
+            , filterTags = "aTag\nanotherTag"
+            , includeOthers = False
+            , includeUntagged = True
+            , title = "A tagboard"
+            }
+        , BoardConfig.DateBoardConfig
+            { completedCount = 15
+            , filterPaths = "date/path"
+            , filterTags = "dateTag"
+            , includeUndated = False
+            , title = "A dateboard"
+            }
+        ]
+    , globalSettings = exampleGlobalSettings
     , version = Semver.version 0 2 0 [] []
     }
 
 
-defaultGlobalSettings : CardBoardSettings.GlobalSettings
-defaultGlobalSettings =
-    { hideCompletedSubtasks = False
-    , ignorePaths = ""
-    , subTaskDisplayLimit = Nothing
+exampleGlobalSettings : CardBoardSettings.GlobalSettings
+exampleGlobalSettings =
+    { hideCompletedSubtasks = True
+    , ignorePaths = "a/path"
+    , subTaskDisplayLimit = Just 17
     }
 
 

--- a/tests/DateBoardTests.elm
+++ b/tests/DateBoardTests.elm
@@ -105,26 +105,14 @@ columnUndated =
 encodeDecode : Test
 encodeDecode =
     describe "encoding and decoding config"
-        [ test "encodes config correctly" <|
+        [ test "can decode the encoded string back to the original" <|
             \() ->
-                defaultConfig
-                    |> TsEncode.runExample DateBoard.configEncoder
-                    |> .output
-                    |> Expect.equal """{"completedCount":0,"includeUndated":false,"title":"Date Board Title"}"""
-        , test "produces the expected type" <|
-            \() ->
-                defaultConfig
-                    |> TsEncode.runExample DateBoard.configEncoder
-                    |> .tsType
-                    |> Expect.equal "{ completedCount : number; includeUndated : boolean; title : string }"
-        , test "can decode the encoded string back to the original" <|
-            \() ->
-                defaultConfig
+                exampleConfig
                     |> TsEncode.runExample DateBoard.configEncoder
                     |> .output
                     |> runDecoder DateBoard.configDecoder
                     |> .decoded
-                    |> Expect.equal (Ok defaultConfig)
+                    |> Expect.equal (Ok exampleConfig)
         ]
 
 
@@ -135,6 +123,18 @@ encodeDecode =
 defaultConfig : DateBoard.Config
 defaultConfig =
     { completedCount = 0
+    , filterPaths = ""
+    , filterTags = ""
+    , includeUndated = False
+    , title = "Date Board Title"
+    }
+
+
+exampleConfig : DateBoard.Config
+exampleConfig =
+    { completedCount = 12
+    , filterPaths = "a/path\nb/path"
+    , filterTags = "tag1\ntag2"
     , includeUndated = False
     , title = "Date Board Title"
     }

--- a/tests/InteropDefinitionsTests.elm
+++ b/tests/InteropDefinitionsTests.elm
@@ -24,7 +24,7 @@ flagsTests =
     describe "interop.flags (decoding)"
         [ test "decodes valid flags for settings version 0.2.0" <|
             \() ->
-                """{"now":11,"zone":22,"settings":{"version":"0.2.0","data":{"globalSettings":{},"boardConfigs":[{"tag":"dateBoardConfig","data":{"completedCount":4,"includeUndated":true,"title":"date board title"}},{"tag":"tagBoardConfig","data":{"columns":[{"tag":"tag 1","displayTitle":"title 1"}],"completedCount":5,"includeOthers":false,"includeUntagged":true,"title":"tag board title"}}]}}}"""
+                """{"now":11,"zone":22,"settings":{"version":"0.2.0","data":{"globalSettings":{},"boardConfigs":[{"tag":"dateBoardConfig","data":{"completedCount":4,"filterPaths":"a/path","filterTags":"tag1","includeUndated":true,"title":"date board title"}},{"tag":"tagBoardConfig","data":{"columns":[{"tag":"tag 1","displayTitle":"title 1"}],"completedCount":5,"filterPaths":"b/path","filterTags":"tag2","includeOthers":false,"includeUntagged":true,"title":"tag board title"}}]}}}"""
                     |> runDecoder interop.flags
                     |> .decoded
                     |> Expect.equal
@@ -34,12 +34,16 @@ flagsTests =
                                 , boardConfigs =
                                     [ BoardConfig.DateBoardConfig
                                         { completedCount = 4
+                                        , filterPaths = "a/path"
+                                        , filterTags = "tag1"
                                         , includeUndated = True
                                         , title = "date board title"
                                         }
                                     , BoardConfig.TagBoardConfig
                                         { columns = [ { displayTitle = "title 1", tag = "tag 1" } ]
                                         , completedCount = 5
+                                        , filterPaths = "b/path"
+                                        , filterTags = "tag2"
                                         , includeOthers = False
                                         , includeUntagged = True
                                         , title = "tag board title"
@@ -63,12 +67,16 @@ flagsTests =
                                 , boardConfigs =
                                     [ BoardConfig.DateBoardConfig
                                         { completedCount = 4
+                                        , filterPaths = ""
+                                        , filterTags = ""
                                         , includeUndated = True
                                         , title = "date board title"
                                         }
                                     , BoardConfig.TagBoardConfig
                                         { columns = [ { displayTitle = "title 1", tag = "tag 1" } ]
                                         , completedCount = 5
+                                        , filterPaths = ""
+                                        , filterTags = ""
                                         , includeOthers = False
                                         , includeUntagged = True
                                         , title = "tag board title"
@@ -196,23 +204,6 @@ toElmTests =
                     |> .decoded
                     |> Result.toMaybe
                     |> Expect.equal Nothing
-        , test "builds the correct (toELm) tsType" <|
-            \() ->
-                ""
-                    |> runDecoder interop.toElm
-                    |> .tsType
-                    |> Expect.equal
-                        ("{ data : boolean; tag : \"activeStateUpdated\" }"
-                            ++ " | { data : { fileContents : string; fileDate : string | null; filePath : string }; tag : \"fileAdded\" }"
-                            ++ " | { data : string; tag : \"fileDeleted\" }"
-                            ++ " | { data : { newPath : string; oldPath : string }; tag : \"fileRenamed\" }"
-                            ++ " | { data : { fileContents : string; fileDate : string | null; filePath : string }; tag : \"fileUpdated\" }"
-                            ++ " | { data : JsonValue; tag : \"initCompleted\" }"
-                            ++ " | { data : ({ version : string } & ({ data : JsonValue } | { data : { boardConfigs :"
-                            ++ " ({ data : { completedCount : number; includeUndated : boolean; title : string }; tag : \"dateBoardConfig\" } | { data : { columns : { displayTitle : string; tag : string }[]; completedCount : number; includeOthers : boolean; includeUntagged : boolean; title : string }; tag : \"tagBoardConfig\" }"
-                            ++ ")[] } } | { data : { boardConfigs : ({ data : { completedCount : number; includeUndated : boolean; title : string }; tag : \"dateBoardConfig\" } | { data : { columns : { displayTitle : string; tag : string }[]; completedCount : number; includeOthers : boolean; includeUntagged : boolean; title : string }; tag : \"tagBoardConfig\" })[]; globalSettings : JsonValue } })); tag : \"settingsUpdated\" }"
-                            ++ " | { data : number; tag : \"showBoard\" }"
-                        )
         ]
 
 

--- a/tests/InteropDefinitionsTests.elm
+++ b/tests/InteropDefinitionsTests.elm
@@ -24,7 +24,7 @@ flagsTests =
     describe "interop.flags (decoding)"
         [ test "decodes valid flags for settings version 0.2.0" <|
             \() ->
-                """{"now":11,"zone":22,"settings":{"version":"0.2.0","data":{"globalSettings":{},"boardConfigs":[{"tag":"dateBoardConfig","data":{"completedCount":4,"filterPaths":"a/path","filterTags":"tag1","includeUndated":true,"title":"date board title"}},{"tag":"tagBoardConfig","data":{"columns":[{"tag":"tag 1","displayTitle":"title 1"}],"completedCount":5,"filterPaths":"b/path","filterTags":"tag2","includeOthers":false,"includeUntagged":true,"title":"tag board title"}}]}}}"""
+                """{"now":11,"zone":22,"settings":{"version":"0.2.0","data":{"globalSettings":{"hideCompletedSubtasks":true,"ignorePaths":"pathsToIgnore","subTaskDisplayLimit":7},"boardConfigs":[{"tag":"dateBoardConfig","data":{"completedCount":4,"filterPaths":"a/path","filterTags":"tag1","includeUndated":true,"title":"date board title"}},{"tag":"tagBoardConfig","data":{"columns":[{"tag":"tag 1","displayTitle":"title 1"}],"completedCount":5,"filterPaths":"b/path","filterTags":"tag2","includeOthers":false,"includeUntagged":true,"title":"tag board title"}}]}}}"""
                     |> runDecoder interop.flags
                     |> .decoded
                     |> Expect.equal
@@ -49,7 +49,11 @@ flagsTests =
                                         , title = "tag board title"
                                         }
                                     ]
-                                , globalSettings = defaultGlobalSettings
+                                , globalSettings =
+                                    { hideCompletedSubtasks = True
+                                    , ignorePaths = "pathsToIgnore"
+                                    , subTaskDisplayLimit = Just 7
+                                    }
                                 }
                             , now = 11
                             , zone = 22

--- a/tests/TagBoardTests.elm
+++ b/tests/TagBoardTests.elm
@@ -198,7 +198,7 @@ columnsBasic =
                         }
                     |> tasksInColumn "Bar Tasks"
                     |> List.concatMap TaskItem.tags
-                    |> Expect.equal [ "bar/baz", "baz"  ]
+                    |> Expect.equal [ "bar/baz", "baz" ]
         , test "sorts cards by title & due date" <|
             \() ->
                 """- [ ] b #foo @due(2020-01-01)
@@ -447,26 +447,14 @@ columnConfigsParserTest =
 encodeDecode : Test
 encodeDecode =
     describe "encoding and decoding config"
-        [ test "encodes config correctly" <|
+        [ test "can decode the encoded string back to the original" <|
             \() ->
-                { defaultConfig | columns = [ { tag = "foo", displayTitle = "bar" } ] }
-                    |> TsEncode.runExample TagBoard.configEncoder
-                    |> .output
-                    |> Expect.equal """{"columns":[{"tag":"foo","displayTitle":"bar"}],"completedCount":0,"includeOthers":false,"includeUntagged":false,"title":"Tag Board Title"}"""
-        , test "produces the expected type" <|
-            \() ->
-                { defaultConfig | columns = [ { tag = "foo", displayTitle = "bar" } ] }
-                    |> TsEncode.runExample TagBoard.configEncoder
-                    |> .tsType
-                    |> Expect.equal "{ columns : { displayTitle : string; tag : string }[]; completedCount : number; includeOthers : boolean; includeUntagged : boolean; title : string }"
-        , test "can decode the encoded string back to the original" <|
-            \() ->
-                { defaultConfig | columns = [ { tag = "foo", displayTitle = "bar" } ] }
+                exampleConfig
                     |> TsEncode.runExample TagBoard.configEncoder
                     |> .output
                     |> runDecoder TagBoard.configDecoder
                     |> .decoded
-                    |> Expect.equal (Ok { defaultConfig | columns = [ { tag = "foo", displayTitle = "bar" } ] })
+                    |> Expect.equal (Ok exampleConfig)
         ]
 
 
@@ -478,8 +466,22 @@ defaultConfig : TagBoard.Config
 defaultConfig =
     { columns = []
     , completedCount = 0
+    , filterPaths = ""
+    , filterTags = ""
     , includeOthers = False
     , includeUntagged = False
+    , title = "Tag Board Title"
+    }
+
+
+exampleConfig : TagBoard.Config
+exampleConfig =
+    { columns = [ { tag = "foo", displayTitle = "bar" } ]
+    , completedCount = 6
+    , filterPaths = "a\nb\nc"
+    , filterTags = "t1\nt2\nt3"
+    , includeOthers = False
+    , includeUntagged = True
     , title = "Tag Board Title"
     }
 


### PR DESCRIPTION
Implemented #17 to hide completed subtasks, and ended up just following the pattern and implemented #16 as well since that was a minor additional change. It first filters out completed subtasks then limits the length so that completed subtasks do not count toward the display limit.

Also, in my manual testing I found that it was difficult to get an overview of the task progress so I added a subtask count display in the upper right corner of the card.

This PR is a DRAFT as I would like to get feedback on how GlobalSettings is handled as well as on the other added code. Also, set `new_settings` as the target branch just in case it was good enough to be merged before `new_settings` itself was ready.

A few QoL improvements that could be made yet:
- Implement a delay between when a subtask is completed and when it disappears from the list if 'hide' is true
  - I'm guessing the card update is triggered by the file being written, which is triggered by the checkbox being checked. Not sure how to go about writing the file and showing the checkbox checked but hiding it after a delay.
- Implement a chart for the completion display instead of 'complete / total'
  - Spent a little time looking but figured MVP was better to start so I just put the raw numbers there for now