### PR TITLE
ImproveTagParsing: Stop tag parsing at any invalid tag character

### DIFF
--- a/src/ParserHelper.elm
+++ b/src/ParserHelper.elm
@@ -207,7 +207,7 @@ anyLineParser =
 nonEmptyLineParser : Parser String
 nonEmptyLineParser =
     P.getChompedString chompWithEndOfLine
-        |> P.andThen (checkIfEmpty "nonEmptyLineParser")
+        |> P.andThen (failIfEmpty "nonEmptyLineParser")
 
 
 dateParser : Parser Date
@@ -247,19 +247,20 @@ lineEndOrEnd =
 nonEmptyStringParser : Parser String
 nonEmptyStringParser =
     P.getChompedString chompToEndOfLine
-        |> P.andThen (checkIfEmpty "nonEmptyStringParser")
+        |> P.andThen (failIfEmpty "nonEmptyStringParser")
 
 
 wordParser : Parser String
 wordParser =
     P.getChompedString chompToEndOfWord
-        |> P.andThen (checkIfEmpty "wordParser")
+        |> P.andThen (failIfEmpty "wordParser")
 
 
 tagParser : Parser String
 tagParser = 
     P.getChompedString chompToEndOfTag
-        |> P.andThen (checkIfEmpty "tagParser")
+        |> P.andThen (failIfEmpty "tagParser")
+        |> P.andThen (failIfInt "tagParser")
 
 
 checkWhitespaceFollows : Parser a -> Parser a
@@ -302,11 +303,19 @@ chompToEndOfTag =
     P.chompWhile (not << isEndOfTag)
 
 
-checkIfEmpty : String -> String -> Parser String
-checkIfEmpty calledFrom parsedString =
+failIfEmpty : String -> String -> Parser String
+failIfEmpty calledFrom parsedString =
     if String.length parsedString == 0 then
         P.problem <| "Empty string found in " ++ calledFrom
 
+    else
+        P.succeed parsedString
+
+
+failIfInt : String -> String -> Parser String
+failIfInt calledFrom parsedString =
+    if String.toInt parsedString /= Nothing then
+        P.problem <| "Parsed string is only an int, found in " ++ calledFrom
     else
         P.succeed parsedString
 

--- a/src/ParserHelper.elm
+++ b/src/ParserHelper.elm
@@ -4,10 +4,12 @@ module ParserHelper exposing
     , checkWhitespaceFollows
     , dateParser
     , indentParser
+    , isEndOfTag
     , isSpaceOrTab
     , lineEndOrEnd
     , nonEmptyStringParser
     , spaces
+    , tagParser
     , timeParser
     , wordParser
     )
@@ -28,6 +30,16 @@ type ParseResult b
 
 
 -- TESTS
+
+
+isEndOfTag : Char -> Bool
+isEndOfTag char =
+    -- Alphanumeric, _ and - are valid tag characters
+    if Char.isAlphaNum char then False
+    else if char == '_' then False
+    else if char == '-' then False
+    else if char == '/' then False
+    else True
 
 
 isLineEnd : Char -> Bool
@@ -242,7 +254,12 @@ wordParser : Parser String
 wordParser =
     P.getChompedString chompToEndOfWord
         |> P.andThen (checkIfEmpty "wordParser")
-        |> checkWhitespaceFollows
+
+
+tagParser : Parser String
+tagParser = 
+    P.getChompedString chompToEndOfTag
+        |> P.andThen (checkIfEmpty "tagParser")
 
 
 checkWhitespaceFollows : Parser a -> Parser a
@@ -278,6 +295,11 @@ chompToEndOfWord : Parser ()
 chompToEndOfWord =
     P.succeed ()
         |. P.chompWhile (not << isSpaceTabOrLineEnd)
+
+
+chompToEndOfTag : Parser ()
+chompToEndOfTag =
+    P.chompWhile (not << isEndOfTag)
 
 
 checkIfEmpty : String -> String -> Parser String

--- a/src/TaskItem.elm
+++ b/src/TaskItem.elm
@@ -456,7 +456,10 @@ taskItemFieldsBuilder startOffset startColumn path row completion_ dueFromFile c
         extractTag content ts =
             case content of
                 ObsidianTag t ->
-                    t :: ts
+                    List.head (String.split ":" t)
+                        |> Maybe.withDefault ""
+                        |> List.singleton
+                        |> (\l -> List.append l ts) 
 
                 _ ->
                     ts

--- a/src/TaskItem.elm
+++ b/src/TaskItem.elm
@@ -585,7 +585,7 @@ obsidianTagParser : Parser Content
 obsidianTagParser =
     P.succeed ObsidianTag
         |. P.token "#"
-        |= ParserHelper.wordParser
+        |= ParserHelper.tagParser
 
 
 prefixParser : Parser Completion

--- a/src/TaskItem.elm
+++ b/src/TaskItem.elm
@@ -456,11 +456,7 @@ taskItemFieldsBuilder startOffset startColumn path row completion_ dueFromFile c
         extractTag content ts =
             case content of
                 ObsidianTag t ->
-                    List.head (String.split ":" t)
-                        |> Maybe.withDefault ""
-                        |> List.singleton
-                        |> (\l -> List.append l ts) 
-
+                    t :: ts
                 _ ->
                     ts
 

--- a/tests/ParserHelperTests.elm
+++ b/tests/ParserHelperTests.elm
@@ -273,6 +273,12 @@ tagParserTests =
                 "foo-bar"
                     |> P.run tagParser
                     |> Expect.equal (Ok <| "foo-bar")
+        , test "fails to parse tag string that is only digits" <|
+            \() ->
+                "1234"
+                    |> P.run tagParser
+                    |> Result.toMaybe
+                    |> Expect.equal Nothing
         ]
 
 

--- a/tests/ParserHelperTests.elm
+++ b/tests/ParserHelperTests.elm
@@ -3,7 +3,7 @@ module ParserHelperTests exposing (suite)
 import Date
 import Expect
 import Parser as P exposing ((|.), (|=))
-import ParserHelper exposing (anyLineParser, booleanParser, dateParser, nonEmptyStringParser, timeParser, wordParser)
+import ParserHelper exposing (anyLineParser, booleanParser, dateParser, nonEmptyStringParser, tagParser, timeParser, wordParser)
 import Test exposing (..)
 import Time exposing (Month(..))
 
@@ -17,6 +17,7 @@ suite =
         , dateParserTests
         , indentParserTests
         , nonEmptyStringParserTest
+        , tagParserTests
         , timeParserTests
         , wordParserTest
         ]
@@ -241,6 +242,37 @@ baz
                     |> P.run nonEmptyStringParser
                     |> Result.withDefault "eek"
                     |> Expect.equal "eek"
+        ]
+
+
+tagParserTests: Test
+tagParserTests =
+    describe "parsing tag names"
+        [ test "parse valid normal tag" <|
+            \() ->
+                "foo"
+                    |> P.run tagParser
+                    |> Expect.equal (Ok <| "foo")
+        , test "parse tag with colon" <|
+            \() ->
+                "foo:bar"
+                    |> P.run tagParser
+                    |> Expect.equal (Ok <| "foo")
+        , test "parse tag with subtag" <|
+            \() ->
+                "foo/bar"
+                    |> P.run tagParser
+                    |> Expect.equal (Ok <| "foo/bar")
+        , test "parse tag with underscore" <|
+            \() ->
+                "foo_bar"
+                    |> P.run tagParser
+                    |> Expect.equal (Ok <| "foo_bar")
+        , test "parse tag with hyphen" <|
+            \() ->
+                "foo-bar"
+                    |> P.run tagParser
+                    |> Expect.equal (Ok <| "foo-bar")
         ]
 
 

--- a/tests/TaskListTests.elm
+++ b/tests/TaskListTests.elm
@@ -218,6 +218,14 @@ not a task
                     |> Result.withDefault TaskList.empty
                     |> TaskList.taskIds
                     |> Expect.equal [ "file_a:1", "file_a:4", "file_a:6" ]
+        , test "correctly parses tags with a colon" <|
+            \() ->
+                "- [ ] foo #bar:baz"
+                    |> Parser.run (TaskList.parser "" Nothing)
+                    |> Result.withDefault TaskList.empty
+                    |> TaskList.topLevelTasks
+                    |> List.concatMap TaskItem.tags
+                    |> Expect.equal [ "bar"]
         ]
 
 


### PR DESCRIPTION
Obsidian tags start with a # and then can have a mix of alphanumeric characters, _, -, or /. A tag also cannot be strictly a number. Adjusted the tag parser so that it handles tags in the same way as Obsidian does.

Closes #56 