### PR TITLE
126 Enable asterisk list markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ do this, it must:
 
 - Be in a markdown file.
 - Not be indented.
-- Have the format: `- [ ] Task title`.
+- Have the format: `- [ ] Task title`. The format `* [ ] Task title` will also be recognised, but won't stay in that format when you edit the task.
 
 What appears on the card depends on what your task looks like:
 

--- a/src/TaskItem.elm
+++ b/src/TaskItem.elm
@@ -586,10 +586,16 @@ prefixParser =
     P.oneOf
         [ P.succeed Incomplete
             |. P.token "- [ ] "
+        , P.succeed Incomplete
+            |. P.token "* [ ] "
         , P.succeed Completed
             |. P.token "- [x] "
         , P.succeed Completed
             |. P.token "- [X] "
+        , P.succeed Completed
+            |. P.token "* [x] "
+        , P.succeed Completed
+            |. P.token "* [X] "
         ]
 
 

--- a/tests/TaskItemTests.elm
+++ b/tests/TaskItemTests.elm
@@ -71,6 +71,12 @@ completion =
                     |> Parser.run TaskItemHelpers.basicParser
                     |> Result.map TaskItem.completion
                     |> Expect.equal (Ok Incomplete)
+        , test "returns Incomplete for an incomplete task marked with an asterisk" <|
+            \() ->
+                "* [ ] foo"
+                    |> Parser.run TaskItemHelpers.basicParser
+                    |> Result.map TaskItem.completion
+                    |> Expect.equal (Ok Incomplete)
         , test "returns Complete for a completed task with no inline completion date" <|
             \() ->
                 "- [x] foo"
@@ -712,12 +718,12 @@ parsing =
                     |> Parser.run TaskItemHelpers.basicParser
                     |> Result.mapError (always "failed")
                     |> Expect.equal (Err "failed")
-        , test "fails to parse a task with a '*' as the list marker" <|
+        , test "successfully parses a task with '*' as the list marker" <|
             \() ->
                 "* [X] foo"
                     |> Parser.run TaskItemHelpers.basicParser
-                    |> Result.mapError (always "failed")
-                    |> Expect.equal (Err "failed")
+                    |> Result.map (always "success")
+                    |> Expect.equal (Ok "success")
         , test "fails to parse a task when there is no gap between the title and the ']'" <|
             \() ->
                 "- [X]foo"


### PR DESCRIPTION
Enable asterisk list markers:

```md
* [ ]
```

See discussion here: https://github.com/roovo/obsidian-card-board/issues/126